### PR TITLE
Integrate HistorialAPI and remove MockAPI from HistorialView

### DIFF
--- a/FilaCero/FilaCero/Models/HistorialAPI.swift
+++ b/FilaCero/FilaCero/Models/HistorialAPI.swift
@@ -1,0 +1,131 @@
+//
+//  HistorialAPI.swift
+//  FilaCero
+//
+//  Created by Jordy Granados on 24/09/25.
+//
+
+import Foundation
+
+struct HistorialResponse: Decodable {
+    let ok: Bool
+    let page: Int
+    let size: Int
+    let total: Int
+    let items: [HistorialItemDTO]
+}
+
+struct HistorialItemDTO: Decodable {
+    let id: Int
+    let ventanillaCodigo: Int
+    let folioTurno: String
+    let pacienteNombre: String
+    let ventanilleroNombre: String
+    let sesionEstado: String
+    let turnoEstado: String
+    let prioridad: String
+    let inicio: Date
+    let llamado: Date?
+    let fin: Date?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case ventanillaCodigo = "ventanilla_codigo"
+        case folioTurno       = "folio_turno"
+        case pacienteNombre   = "paciente_nombre"
+        case ventanilleroNombre = "ventanillero_nombre"
+        case sesionEstado     = "sesion_estado"
+        case turnoEstado      = "turno_estado"
+        case prioridad
+        case inicio, llamado, fin
+    }
+}
+
+struct HistorialAPI {
+    let baseURL: URL
+    let session: URLSession
+
+    init(baseURL: URL = URL(string: "https://las-chicas-superpoderosas.tc2007b.tec.mx:10207")!,
+         session: URLSession = .shared) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    func fetch(
+        page: Int,
+        size: Int,
+        ventanilla: Int?,
+        prioridad: Prioridad?,
+        desde: Date?,
+        hasta: Date?,
+        query: String
+    ) async throws -> [Atencion] {
+        var comps = URLComponents(url: baseURL.appendingPathComponent("/historial/atenciones"),
+                                  resolvingAgainstBaseURL: false)
+        var q: [URLQueryItem] = [
+            URLQueryItem(name: "page", value: String(page)),
+            URLQueryItem(name: "size", value: String(size))
+        ]
+        if let v = ventanilla { q.append(URLQueryItem(name: "ventanilla", value: String(v))) }
+        if let p = prioridad { q.append(URLQueryItem(name: "prioridad", value: p.rawValue)) }
+        if let d = desde { q.append(URLQueryItem(name: "desde", value: Self.yyyyMMdd(d))) }
+        if let h = hasta { q.append(URLQueryItem(name: "hasta", value: Self.yyyyMMdd(h))) }
+        if !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            q.append(URLQueryItem(name: "q", value: query))
+        }
+        comps?.queryItems = q
+        guard let url = comps?.url else { throw URLError(.badURL) }
+
+        var req = URLRequest(url: url)
+        req.httpMethod = "GET"
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let (data, resp) = try await session.data(for: req)
+        guard let http = resp as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            let msg = String(data: data, encoding: .utf8) ?? "HTTP error"
+            throw NSError(domain: "HistorialAPI", code: (resp as? HTTPURLResponse)?.statusCode ?? -1,
+                          userInfo: [NSLocalizedDescriptionKey: msg])
+        }
+
+        let dec = JSONDecoder()
+        dec.dateDecodingStrategy = .iso8601
+        let payload = try dec.decode(HistorialResponse.self, from: data)
+
+        return payload.items.map { dto in
+            Atencion(
+                id: dto.id,
+                ventanillaCodigo: dto.ventanillaCodigo,
+                folioTurno: dto.folioTurno,
+                pacienteNombre: dto.pacienteNombre,
+                ventanilleroNombre: dto.ventanilleroNombre,
+                sesionEstado: SesionEstado(rawValue: dto.sesionEstado) ?? .asignado,
+                turnoEstado: TurnoEstado(rawValue: dto.turnoEstado) ?? .pendiente,
+                prioridad: Prioridad(rawValue: dto.prioridad) ?? .normal,
+                inicio: dto.inicio,
+                llamado: dto.llamado,
+                fin: dto.fin
+            )
+        }
+    }
+
+    private static func yyyyMMdd(_ d: Date) -> String {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(secondsFromGMT: 0)!
+        let c = cal.dateComponents([.year,.month,.day], from: d)
+        return String(format: "%04d-%02d-%02d", c.year!, c.month!, c.day!)
+    }
+}
+
+extension HistorialAPI {
+    static func fetch(page: Int, size: Int) async throws -> [Atencion] {
+        try await HistorialAPI().fetch(
+            page: page,
+            size: size,
+            ventanilla: nil,
+            prioridad: nil,
+            desde: nil,
+            hasta: nil,
+            query: ""
+        )
+    }
+}

--- a/FilaCero/FilaCero/ViewsAdmin/Views/HistorialView.swift
+++ b/FilaCero/FilaCero/ViewsAdmin/Views/HistorialView.swift
@@ -83,7 +83,7 @@ final class HistorialVentanillasVM: ObservableObject {
         isLoading = true; error = nil; page = 0
         items = []; filtered = []
         do {
-            let nuevos = try await MockAPI.fetch(page: page, size: pageSize)
+            let nuevos = try await HistorialAPI.fetch(page: page, size: pageSize)
             items = nuevos
             applyFilters()
             isLoading = false
@@ -106,7 +106,7 @@ final class HistorialVentanillasVM: ObservableObject {
         isLoading = true; defer { isLoading = false }
         page += 1
         do {
-            let nuevos = try await MockAPI.fetch(page: page, size: pageSize)
+            let nuevos = try await HistorialAPI.fetch(page: page, size: pageSize)
             items.append(contentsOf: nuevos)
             applyFilters()
         } catch { self.error = error.localizedDescription }
@@ -388,45 +388,6 @@ struct FiltrosSheet: View {
         desde = Calendar.current.date(byAdding: .day, value: -7, to: Date())!
         usarHasta = false
         hastaValor = desde
-    }
-}
-
-// MARK: - Mock API
-enum MockAPI {
-    static func fetch(page: Int, size: Int) async throws -> [Atencion] {
-        try await Task.sleep(nanoseconds: 200_000_000)
-        let base = Date()
-        var out: [Atencion] = []
-        for i in 0..<size {
-            let dayOffset = Int.random(in: 0...6)
-            let inicio = Calendar.current.date(byAdding: .minute, value: -Int.random(in: 5...480), to: Calendar.current.date(byAdding: .day, value: -dayOffset, to: base)!)!
-            let espera = Int.random(in: 1...20) * 60
-            let servicio = Int.random(in: 5...35) * 60
-
-            let sesionEstado: SesionEstado = [.terminado, .asignado].randomElement()!
-            let turnoEstado: TurnoEstado = [.completado, .pendiente, .cancelado].randomElement()!
-            let prioridad: Prioridad = [.normal, .especial].randomElement()!
-
-            let llamado = Bool.random() ? inicio.addingTimeInterval(TimeInterval(espera)) : nil
-            let fin: Date? = (sesionEstado == .terminado) ? (llamado ?? inicio).addingTimeInterval(TimeInterval(servicio)) : nil
-
-            out.append(
-                Atencion(
-                    id: page*size + i,
-                    ventanillaCodigo: Int.random(in: 1...8),
-                    folioTurno: "A-\(1000 + page*size + i)",
-                    pacienteNombre: ["Juan Pérez","María López","Luis Díaz","Ana Ruiz"].randomElement()!,
-                    ventanilleroNombre: ["Karla R.","Roberto G.","Sara M.","Miguel T."].randomElement()!,
-                    sesionEstado: sesionEstado,
-                    turnoEstado: turnoEstado,
-                    prioridad: prioridad,
-                    inicio: inicio,
-                    llamado: llamado,
-                    fin: fin
-                )
-            )
-        }
-        return out
     }
 }
 


### PR DESCRIPTION
Added HistorialAPI for fetching historical data from the backend and replaced all usages of MockAPI in HistorialView with HistorialAPI. Removed the MockAPI implementation from HistorialView to use real API data instead of mock data.